### PR TITLE
Remove all automatic casts to floats from integers for shaders

### DIFF
--- a/assets/shaders/noire.fs
+++ b/assets/shaders/noire.fs
@@ -178,7 +178,7 @@ vec4 effect( vec4 colour, Image texture, vec2 texture_coords, vec2 screen_coords
 {
     vec4 tex = Texel( texture, texture_coords);
     vec2 uv = (((texture_coords)*(image_details)) - texture_details.xy*texture_details.ba)/texture_details.ba;
-    vec3 should_highlight = (1-smoothstep(vec3(0),vec3(0.5),tex.xyz));
+    vec3 should_highlight = (1-smoothstep(vec3(0.),vec3(0.5),tex.xyz));
 
     number low = min(tex.r, min(tex.g, tex.b));
     number high = max(tex.r, max(tex.g, tex.b));
@@ -195,7 +195,7 @@ vec4 effect( vec4 colour, Image texture, vec2 texture_coords, vec2 screen_coords
     // modify tex.rgb for output
 	// maxfac is probably max factor for like shine or something idk
     // ok fac 5 is the shine when you move mouse -> <- and it does the woosh thing
-    float rand = pnoise(vec3(uv * 0.2 + noire.x*noire.y*0.000001, sin(noire.y*0.01)*10),vec3(1.3,4.45,2.13)) * 0.6;
+    float rand = pnoise(vec3(uv * 0.2 + noire.x*noire.y*0.000001, sin(noire.y*0.01)*10.),vec3(1.3,4.45,2.13)) * 0.6;
 	tex.xyz = vec3(1.)-tex.xyz;
 
     tex.xyz += (should_highlight*((max(0.6,maxfac*4)+1.1)));
@@ -206,10 +206,10 @@ vec4 effect( vec4 colour, Image texture, vec2 texture_coords, vec2 screen_coords
     tex.z *= 0.7;
 
     vec4 newCol = HSL(vec4(tex.xyz,1.0));
-    newCol.x += (screen_coords.x/200 + screen_coords.y/200+ sin(noire.y*0.0111)) + sin(noire.y*10)*0.00002;
-    newCol.x *= min(max(0.3,pnoise(vec3(uv * 0.3 + noire.x, sin(noire.y*0.1)*10),vec3(1.1,2.4,3.3))),0.7) * (sin(time)+3)*0.25;
+    newCol.x += (screen_coords.x/200. + screen_coords.y/200.+ sin(noire.y*0.0111)) + sin(noire.y*10.)*0.00002;
+    newCol.x *= min(max(0.3,pnoise(vec3(uv * 0.3 + noire.x, sin(noire.y*0.1)*10.),vec3(1.1,2.4,3.3))),0.7) * (sin(time)+3)*0.25;
     newCol.y *=0.5; // sat
-    newCol.y +=0.7 * ((sin(noire.y)+4) * 0.25);
+    newCol.y +=0.7 * ((sin(noire.y)+4.) * 0.25);
     newCol.z *=0.5; // light
     newCol.z +=0.6 * (noire.x*0.1);
     tex.xyz = mix(RGB(newCol).xyz,tex.xyz,0.8);
@@ -232,6 +232,6 @@ vec4 position( mat4 transform_projection, vec4 vertex_position )
     float scale = 0.2*(-0.03 - 0.3*max(0., 0.3-mid_dist))
                 *hovering*(length(mouse_offset)*length(mouse_offset))/(2. -mid_dist);
 
-    return transform_projection * vertex_position + vec4(0,0,0,scale);
+    return transform_projection * vertex_position + vec4(0.,0.,0.,scale);
 }
 #endif

--- a/assets/shaders/sliced.fs
+++ b/assets/shaders/sliced.fs
@@ -114,7 +114,7 @@ vec4 effect( vec4 colour, Image texture, vec2 texture_coords, vec2 screen_coords
     float random2 = randReal(floor(uv.x*7.445)+1+time)*0.05;
     float random = mix(random1, random2, fract(sin(uv.x*7.445)+time));
     float factor = 0.5 + random;
-    float factorY = 1;
+    float factorY = 1.;
     float width = 0.044 + fract(fract(random)*1.72);
     float widthRed = 0.2;
     vec4 tex = Texel(texture, texture_coords);
@@ -122,11 +122,11 @@ vec4 effect( vec4 colour, Image texture, vec2 texture_coords, vec2 screen_coords
 
     vec4 COLHSL = HSL(tex);
     COLHSL.g = COLHSL.g + 0.000001*sliced.r;
-    //COLHSL.b = 1 - COLHSL.b;
+    //COLHSL.b = 1. - COLHSL.b;
     // -- end
 	tex = RGB(COLHSL);
     vec2 newuv = uv;
-    if ((uv.x*factor)+uv.y*factorY > (1)-factor/2 && (uv.x*factor)+uv.y*factorY < (1+widthRed/2)-(factor/2)){
+    if ((uv.x*factor)+uv.y*factorY > (1.)-factor/2. && (uv.x*factor)+uv.y*factorY < (1.+widthRed/2.)-(factor/2.)){
         //tex.r *= 5.0;
         //tex.r += 1.0;
         //tex.g *= 0.010;
@@ -140,9 +140,9 @@ vec4 effect( vec4 colour, Image texture, vec2 texture_coords, vec2 screen_coords
         tex.b -= 0.2;
 
     }
-    if ((uv.x*factor)+uv.y*factorY > (1-width/2)-(factor/2) && uv.x*factor+uv.y*factorY < (1+width/2)-(factor/2)){
-        tex.w = 0;
-        colour.w = 0;
+    if ((uv.x*factor)+uv.y*factorY > (1.-width/2.)-(factor/2.) && uv.x*factor+uv.y*factorY < (1.+width/2)-(factor/2.)){
+        tex.w = 0.;
+        colour.w = 0.;
     }
 
 	return dissolve_mask(tex*colour, texture_coords, newuv);
@@ -163,6 +163,6 @@ vec4 position( mat4 transform_projection, vec4 vertex_position )
     float scale = 0.2*(-0.03 - 0.3*max(0., 0.3-mid_dist))
                 *hovering*(length(mouse_offset)*length(mouse_offset))/(2. -mid_dist);
 
-    return transform_projection * vertex_position + vec4(0,0,0,scale);
+    return transform_projection * vertex_position + vec4(0.,0.,0.,scale);
 }
 #endif

--- a/assets/shaders/texelated.fs
+++ b/assets/shaders/texelated.fs
@@ -97,7 +97,7 @@ vec4 effect( vec4 colour, Image texture, vec2 texture_coords, vec2 screen_coords
 	vec2 uv2 = uv*10.0;
 	vec3 gridval = simplexGrid(uv2);
 	vec3 outgrid = tex.xyz * (vec3(max(gridval.x,max(gridval.y,gridval.z))))*0.7;
-	tex.xyz = outgrid * (maxfac  + 2) * (gridval * 0.8 + 0.6);
+	tex.xyz = outgrid * (maxfac  + 2.) * (gridval * 0.8 + 0.6);
 
 
     return dissolve_mask(tex*colour, texture_coords, uv);
@@ -118,6 +118,6 @@ vec4 position( mat4 transform_projection, vec4 vertex_position )
     float scale = 0.2*(-0.03 - 0.3*max(0., 0.3-mid_dist))
                 *hovering*(length(mouse_offset)*length(mouse_offset))/(2. -mid_dist);
 
-    return transform_projection * vertex_position + vec4(0,0,0,scale);
+    return transform_projection * vertex_position + vec4(0.,0.,0.,scale);
 }
 #endif

--- a/assets/shaders/trimmed_flame.fs
+++ b/assets/shaders/trimmed_flame.fs
@@ -26,7 +26,7 @@ vec4 effect( vec4 colour, Image texture, vec2 texture_coords, vec2 screen_coords
 
     //Convert to UV coords (0-1) and floor for pixel effect
     vec2 uv = (((texture_coords)*(image_details)) - texture_details.xy*texture_details.ba)/texture_details.ba - 0.5;
-    if (uv.y>0) return vec4(0,0,0,0);
+    if (uv.y>0.) return vec4(0.,0.,0.,0.);
     vec2 floored_uv = (floor((uv*PIXEL_SIZE_FAC)))/PIXEL_SIZE_FAC;
     vec2 uv_scaled_centered = (floored_uv);
     uv_scaled_centered += uv_scaled_centered*0.01*(sin(-1.123*floored_uv.x + 0.2*time)*cos(5.3332*floored_uv.y + time*0.931));


### PR DESCRIPTION
If you've ever tried running Balatro mods on Android chances are you're gonna see an error screen that says about not being able to do shit between a `float` and an `int`.

This should fix that.