### PR TITLE
Fix non integer ante crash

### DIFF
--- a/modules/hooks/ui.lua
+++ b/modules/hooks/ui.lua
@@ -877,6 +877,8 @@ end
 
 local ogBlindSel = create_UIBox_blind_choice
 function create_UIBox_blind_choice(type, run_info)
+    G.GAME.round_resets.blind_ante = math.floor((G.GAME.round_resets.blind_ante or G.GAME.round_resets.ante) + 0.5)
+    G.GAME.round_resets.ante = G.GAME.round_resets.blind_ante
     local x = ogBlindSel(type, run_info)
     local bl = G.P_BLINDS[G.GAME.round_resets.blind_choices[type]]
     local elem = AKYRS.search_UIT_for_id(x, "blind_desc")


### PR DESCRIPTION
theres probably a better way to do this but it works (see https://discord.com/channels/1116389027176787968/1326135270759993364/1479332766989418606) - in the scuffed misprint deck when you choose a card that decreases ante by a non-integer it causes it to crash so this fixes it